### PR TITLE
Rename lag

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ dataset.get_timestamp()
 
 # Each dataset can have a list of zero or more past datasets/interactions.
 # You can incorporate them in your retrieval system:
-for past_dataset in dataset.get_past_datasets():
+for past_dataset in dataset.get_prior_datasets():
     # `past_dataset` is an LongEval `ir_dataset` with the same functionality as the `dataset`
     past_dataset.get_timestamp()
 ```

--- a/ir_datasets_longeval/__init__.py
+++ b/ir_datasets_longeval/__init__.py
@@ -20,7 +20,7 @@ def read_property_from_metadata(base_path, property):
     return base
 
 
-def load(longeval_ir_dataset: Union[str, Path]):
+def load(longeval_ir_dataset: Union[str]):
     """Load an LongEval ir_dataset.
     Can point to an official ID of an LongEval dataset or a local directory of the same structure.
 
@@ -28,7 +28,7 @@ def load(longeval_ir_dataset: Union[str, Path]):
     it loads the data from the directory that TIRA mounted into the container as input dataset as specified via the TIRA_INPUT_DATASET variable.
 
     Args:
-        longeval_ir_dataset (Union[str, Path]): the ID of an LongEval ir_dataset or a local path.
+        longeval_ir_dataset (str): the ID of an LongEval ir_dataset or a local path.
     """
     if __is_in_tira_sandbox():
         # we do not have access to the internet in the TIRA sandbox

--- a/ir_datasets_longeval/downloads.json
+++ b/ir_datasets_longeval/downloads.json
@@ -2,7 +2,6 @@
   "longeval-web": {
     "longeval_2025_train_collection": {
       "url": "https://researchdata.tuwien.ac.at/records/th5h0-g5f51/files/Longeval_2025_Train_Collection_p1.zip?download=1&preview=1&token=eyJhbGciOiJIUzUxMiJ9.eyJpZCI6IjcwM2Y4MzQ0LTFlMDEtNDYxNy1iNDc4LTI5MmQ5MzYwNTU3NyIsImRhdGEiOnt9LCJyYW5kb20iOiI4NjYxMWFkODQzNDk2ZDk0NzllMDNlOWIyYWM1Zjc4NCJ9.YhnRV6WzWfQiuLQcGyTrA3gyI_5UBe9rtUAV6qKk5U7tqGEmD4NUdyfjGo2-U7tnBIlD7iTwUUDi0nw3GcXPmA",
-      "instructions": "TBD",
       "cache_path": "Longeval_2025_Train_Collection_p1.zip"
     }
   },

--- a/ir_datasets_longeval/formats.py
+++ b/ir_datasets_longeval/formats.py
@@ -6,5 +6,5 @@ class MetaDataset(Dataset):
         super().__init__()
         self._datasets = datasets
 
-    def get_lags(self):
+    def get_prior_snapshots(self):
         return self._datasets

--- a/ir_datasets_longeval/formats.py
+++ b/ir_datasets_longeval/formats.py
@@ -6,5 +6,5 @@ class MetaDataset(Dataset):
         super().__init__()
         self._datasets = datasets
 
-    def get_prior_snapshots(self):
+    def get_datasets(self):
         return self._datasets

--- a/ir_datasets_longeval/longeval_sci.py
+++ b/ir_datasets_longeval/longeval_sci.py
@@ -65,6 +65,11 @@ class ExtractedPath:
     def __init__(self, path):
         self._path = path
 
+    def path(self, force=True):
+        if force and not self._path.exists():
+            raise FileNotFoundError(self._path)
+        return self._path
+
     @contextlib.contextmanager
     def stream(self):
         with open(self._path, "rb") as f:
@@ -78,7 +83,7 @@ class LongEvalSciDataset(Dataset):
         yaml_documentation: str = "longeval_sci.yaml",
         timestamp: Optional[str] = None,
         prior_datasets: Optional[List[str]] = None,
-        snapshot: Optional[int] = None,
+        snapshot: Optional[str] = None,
     ):
         """LongEvalSciDataset class
 
@@ -87,7 +92,7 @@ class LongEvalSciDataset(Dataset):
             yaml_documentation (str, optional): Documentation file. Defaults to "longeval_sci.yaml".
             timestamp (Optional[str], optional): Timestamp in the YYYY-MM format of the snapshot. Defaults to None.
             prior_datasets (Optional[List[str]], optional): List of all snapshot that come before this snapshot. Defaults to None.
-            snapshot (Optional[int], optional): Index of the sub-collection in the time series. This was previously also referred to as lag. Defaults to None.
+            snapshot (Optional[str], optional): Name of the sub-collection. This was previously also referred to as lag and is most likely similar to the dataset_id. Defaults to None.
         """
         documentation = YamlDocumentation(yaml_documentation)
         self.base_path = base_path
@@ -161,7 +166,7 @@ class LongEvalSciDataset(Dataset):
     def get_snapshot(self):
         return self.snapshot
 
-    def get_prior_snapshots(self):
+    def get_datasets(self):
         return None
 
     def get_prior_datasets(self):
@@ -210,8 +215,8 @@ def register_spot_check_datasets():
             with_prior_data_truths / "qrels.txt", with_prior_data_inputs / "qrels.txt"
         )
 
-    no_prior = LongEvalSciDataset(no_prior_data_inputs, snapshot=1)
-    prior_data = LongEvalSciDataset(with_prior_data_inputs, snapshot=2)
+    no_prior = LongEvalSciDataset(no_prior_data_inputs, snapshot="s1")
+    prior_data = LongEvalSciDataset(with_prior_data_inputs, snapshot="s3")
     registry.register(f"{NAME}/spot-check/no-prior-data", no_prior)
     registry.register(f"{NAME}/spot-check/with-prior-data", prior_data)
     registry.register(f"{NAME}/spot-check/*", MetaDataset([no_prior, prior_data]))
@@ -241,7 +246,7 @@ def register():
         base_path=data_path,
         timestamp="2024-11",
         prior_datasets=[],
-        snapshot=1,
+        snapshot="2024-11-train",
     )
 
     for s in sorted(subsets):

--- a/ir_datasets_longeval/longeval_sci.py
+++ b/ir_datasets_longeval/longeval_sci.py
@@ -216,17 +216,37 @@ def register():
     dlc = DownloadConfig.context(NAME, base_path)
     base_path = home_path() / NAME
 
+
+    subsets = {}
+
+    # 2025 train
     data_path = (
         ZipExtractCache(
             dlc["longeval_sci_training_2025"], base_path / "longeval_sci_training_2025"
         ).path()
         / "longeval_sci_training_2025_abstract"
     )
-
-    subsets = {}
-
+    
     subsets["2024-11/train"] = LongEvalSciDataset(
-        data_path, "2024-11/train", "2024-11", []
+        base_path=data_path,
+        timestamp="2024-11",
+        prior_datasets=[],
+    )
+
+    
+    # 2025 test
+    data_path = (
+        ZipExtractCache(
+            dlc["longeval_sci_training_2025"], base_path / "longeval_sci_training_2025"
+        ).path()
+        / "longeval_sci_training_2025_abstract"
+    )
+    subsets["2024-11"] = LongEvalSciDataset(
+        base_path=data_path, timestamp="2024-11", prior_datasets=[]
+    )
+
+    subsets["2025-01"] = LongEvalSciDataset(
+        base_path=data_path, timestamp="2025-01", prior_datasets=[subsets["2024-11"]]
     )
 
     for s in sorted(subsets):

--- a/ir_datasets_longeval/longeval_sci.py
+++ b/ir_datasets_longeval/longeval_sci.py
@@ -215,8 +215,8 @@ def register_spot_check_datasets():
             with_prior_data_truths / "qrels.txt", with_prior_data_inputs / "qrels.txt"
         )
 
-    no_prior = LongEvalSciDataset(no_prior_data_inputs, snapshot="s1")
-    prior_data = LongEvalSciDataset(with_prior_data_inputs, snapshot="s3")
+    no_prior = LongEvalSciDataset(no_prior_data_inputs, snapshot="2024-10")
+    prior_data = LongEvalSciDataset(with_prior_data_inputs, snapshot="2024-11")
     registry.register(f"{NAME}/spot-check/no-prior-data", no_prior)
     registry.register(f"{NAME}/spot-check/with-prior-data", prior_data)
     registry.register(f"{NAME}/spot-check/*", MetaDataset([no_prior, prior_data]))

--- a/ir_datasets_longeval/longeval_sci.yaml
+++ b/ir_datasets_longeval/longeval_sci.yaml
@@ -4,10 +4,14 @@ _:
   docs_instructions: "TBD"
   data_access: "TBD"
 
+2024-11/train:
+  desc: "TBD"
+  docs_instructions: "TBD"
+
 2024-11:
   desc: "TBD"
   docs_instructions: "TBD"
 
-2024-11/train:
+2025-01:
   desc: "TBD"
   docs_instructions: "TBD"

--- a/ir_datasets_longeval/longeval_web.py
+++ b/ir_datasets_longeval/longeval_web.py
@@ -236,7 +236,7 @@ class LongEvalWebDataset(Dataset):
     def get_snapshot(self):
         return self.snapshot
 
-    def get_prior_snapshots(self):
+    def get_datasets(self):
         return None
 
     def get_prior_datasets(self):
@@ -287,7 +287,7 @@ def register():
             prior_datasets=SUB_COLLECTIONS_TRAIN[
                 : SUB_COLLECTIONS_TRAIN.index(timestamp)
             ],
-            snapshot=SUB_COLLECTIONS_TRAIN.index(timestamp)+1,
+            snapshot=timestamp,
         )
 
     for s in sorted(subsets):

--- a/ir_datasets_longeval/longeval_web.py
+++ b/ir_datasets_longeval/longeval_web.py
@@ -182,7 +182,7 @@ class LongEvalWebDataset(Dataset):
         yaml_documentation: str = "longeval_web.yaml",
         timestamp: Optional[str] = None,
         prior_datasets: Optional[List[str]] = None,
-        lag: Optional[str] = None,
+        snapshot: Optional[str] = None,
     ):
         documentation = YamlDocumentation(yaml_documentation)
         self.base_path = base_path
@@ -198,12 +198,12 @@ class LongEvalWebDataset(Dataset):
 
         self.timestamp = datetime.strptime(timestamp, "%Y-%m")
 
-        if not lag:
+        if not snapshot:
             try:
-                lag = self.read_property_from_metadata("lag")
+                snapshot = self.read_property_from_metadata("snapshot")
             except KeyError:
-                lag = None
-        self.lag = lag
+                snapshot = None
+        self.snapshot = snapshot
 
         if prior_datasets is None:
             prior_datasets = self.read_property_from_metadata("prior-datasets")
@@ -233,13 +233,13 @@ class LongEvalWebDataset(Dataset):
     def get_timestamp(self):
         return self.timestamp
 
-    def get_lag(self):
-        return self.lag
+    def get_snapshot(self):
+        return self.snapshot
 
-    def get_lags(self):
+    def get_prior_snapshots(self):
         return None
 
-    def get_past_datasets(self):
+    def get_prior_datasets(self):
         return [
             LongEvalWebDataset(
                 base_path=self.base_path / i,
@@ -287,6 +287,7 @@ def register():
             prior_datasets=SUB_COLLECTIONS_TRAIN[
                 : SUB_COLLECTIONS_TRAIN.index(timestamp)
             ],
+            snapshot=SUB_COLLECTIONS_TRAIN.index(timestamp)+1,
         )
 
     for s in sorted(subsets):

--- a/ir_datasets_longeval/metadata.json
+++ b/ir_datasets_longeval/metadata.json
@@ -2,12 +2,6 @@
   "longeval-sci/2024-11/train": {
     "lag": "lag-0"
   },
-  "longeval-web": {
-    "queries": {
-      "count": 75427,
-      "max_len": 5425
-    }
-  },
   "longeval-web/2022-06": {
     "lag": "lag-0",
     "qrels": {
@@ -35,6 +29,10 @@
           "max_len": 511
         }
       }
+    },
+    "queries": {
+      "count": 75427,
+      "max_len": 5425
     }
   },
   "longeval-web/2022-07": {
@@ -64,6 +62,10 @@
           "max_len": 511
         }
       }
+    },
+    "queries": {
+      "count": 75427,
+      "max_len": 5425
     }
   },
   "longeval-web/2022-08": {
@@ -93,6 +95,10 @@
           "max_len": 511
         }
       }
+    },
+    "queries": {
+      "count": 75427,
+      "max_len": 5425
     }
   },
   "longeval-web/2022-09": {
@@ -122,6 +128,10 @@
           "max_len": 511
         }
       }
+    },
+    "queries": {
+      "count": 75427,
+      "max_len": 5425
     }
   },
   "longeval-web/2022-10": {
@@ -151,6 +161,10 @@
           "max_len": 511
         }
       }
+    },
+    "queries": {
+      "count": 75427,
+      "max_len": 5425
     }
   },
   "longeval-web/2022-11": {
@@ -180,6 +194,10 @@
           "max_len": 511
         }
       }
+    },
+    "queries": {
+      "count": 75427,
+      "max_len": 5425
     }
   },
   "longeval-web/2022-12": {
@@ -209,6 +227,10 @@
           "max_len": 511
         }
       }
+    },
+    "queries": {
+      "count": 75427,
+      "max_len": 5425
     }
   },
   "longeval-web/2023-01": {
@@ -238,9 +260,32 @@
           "max_len": 511
         }
       }
+    },
+    "queries": {
+      "count": 75427,
+      "max_len": 5425
     }
   },
   "longeval-web/2023-02": {
-    "lag": "lag-8"
+    "lag": "lag-8",
+    "qrels": {
+      "count": 55718,
+      "fields": {
+        "relevance": {
+          "counts_by_value": {
+            "0": 79217,
+            "1": 24909,
+            "2": 29118
+          }
+        }
+      }
+    },
+    "docs": {
+      "count": 2526382
+    },
+    "queries": {
+      "count": 75427,
+      "max_len": 5425
+    }
   }
 }

--- a/ir_datasets_longeval/metadata.json
+++ b/ir_datasets_longeval/metadata.json
@@ -1,15 +1,15 @@
 {
   "longeval-sci/2024-11/train": {
-    "snapshot": 0
+    "snapshot": "2024-11-train"
   },
   "longeval-sci/2024-11": {
-    "snapshot": 0
+    "snapshot": "2024-11"
   },
   "longeval-sci/2025-01": {
-    "snapshot": 1
+    "snapshot": "2025-01"
   },
   "longeval-web/2022-06": {
-    "snapshot": 1,
+    "snapshot": "2022-06",
     "qrels": {
       "count": 85776,
       "fields": {
@@ -42,7 +42,7 @@
     }
   },
   "longeval-web/2022-07": {
-    "snapshot": 2,
+    "snapshot": "2022-07",
     "qrels": {
       "count": 107916,
       "fields": {
@@ -75,7 +75,7 @@
     }
   },
   "longeval-web/2022-08": {
-    "snapshot": 3,
+    "snapshot": "2022-08",
     "qrels": {
       "count": 133001,
       "fields": {
@@ -108,7 +108,7 @@
     }
   },
   "longeval-web/2022-09": {
-    "snapshot": 4,
+    "snapshot": "2022-09",
     "qrels": {
       "count": 135483,
       "fields": {
@@ -141,7 +141,7 @@
     }
   },
   "longeval-web/2022-10": {
-    "snapshot": 5,
+    "snapshot": "2022-10",
     "qrels": {
       "count": 123967,
       "fields": {
@@ -174,7 +174,7 @@
     }
   },
   "longeval-web/2022-11": {
-    "snapshot": 6,
+    "snapshot": "2022-11",
     "qrels": {
       "count": 138031,
       "fields": {
@@ -207,7 +207,7 @@
     }
   },
   "longeval-web/2022-12": {
-    "snapshot": 7,
+    "snapshot": "2022-12",
     "qrels": {
       "count": 139035,
       "fields": {
@@ -240,7 +240,7 @@
     }
   },
   "longeval-web/2023-01": {
-    "snapshot": 8,
+    "snapshot": "2023-01",
     "qrels": {
       "count": 133244,
       "fields": {
@@ -273,7 +273,7 @@
     }
   },
   "longeval-web/2023-02": {
-    "snapshot": 9,
+    "snapshot": "2023-02",
     "qrels": {
       "count": 55718,
       "fields": {

--- a/ir_datasets_longeval/metadata.json
+++ b/ir_datasets_longeval/metadata.json
@@ -1,9 +1,15 @@
 {
   "longeval-sci/2024-11/train": {
-    "lag": "lag-0"
+    "snapshot": 0
+  },
+  "longeval-sci/2024-11": {
+    "snapshot": 0
+  },
+  "longeval-sci/2025-01": {
+    "snapshot": 1
   },
   "longeval-web/2022-06": {
-    "lag": "lag-0",
+    "snapshot": 1,
     "qrels": {
       "count": 85776,
       "fields": {
@@ -36,7 +42,7 @@
     }
   },
   "longeval-web/2022-07": {
-    "lag": "lag-1",
+    "snapshot": 2,
     "qrels": {
       "count": 107916,
       "fields": {
@@ -69,7 +75,7 @@
     }
   },
   "longeval-web/2022-08": {
-    "lag": "lag-2",
+    "snapshot": 3,
     "qrels": {
       "count": 133001,
       "fields": {
@@ -102,7 +108,7 @@
     }
   },
   "longeval-web/2022-09": {
-    "lag": "lag-3",
+    "snapshot": 4,
     "qrels": {
       "count": 135483,
       "fields": {
@@ -135,7 +141,7 @@
     }
   },
   "longeval-web/2022-10": {
-    "lag": "lag-4",
+    "snapshot": 5,
     "qrels": {
       "count": 123967,
       "fields": {
@@ -168,7 +174,7 @@
     }
   },
   "longeval-web/2022-11": {
-    "lag": "lag-5",
+    "snapshot": 6,
     "qrels": {
       "count": 138031,
       "fields": {
@@ -201,7 +207,7 @@
     }
   },
   "longeval-web/2022-12": {
-    "lag": "lag-6",
+    "snapshot": 7,
     "qrels": {
       "count": 139035,
       "fields": {
@@ -234,7 +240,7 @@
     }
   },
   "longeval-web/2023-01": {
-    "lag": "lag-7",
+    "snapshot": 8,
     "qrels": {
       "count": 133244,
       "fields": {
@@ -267,7 +273,7 @@
     }
   },
   "longeval-web/2023-02": {
-    "lag": "lag-8",
+    "snapshot": 9,
     "qrels": {
       "count": 55718,
       "fields": {

--- a/tests/resources/example-local-dataset-no-prior-datasets/metadata.json
+++ b/tests/resources/example-local-dataset-no-prior-datasets/metadata.json
@@ -1,1 +1,1 @@
-{"timestamp": "2024-11", "prior-datasets": [], "snapshot": 1}
+{"timestamp": "2024-11", "prior-datasets": [], "snapshot": "s1"}

--- a/tests/resources/example-local-dataset-no-prior-datasets/metadata.json
+++ b/tests/resources/example-local-dataset-no-prior-datasets/metadata.json
@@ -1,1 +1,1 @@
-{"timestamp": "2024-11", "prior-datasets": [], "lag": "lag-1"}
+{"timestamp": "2024-11", "prior-datasets": [], "snapshot": 1}

--- a/tests/resources/example-local-dataset-two-prior-datasets/metadata.json
+++ b/tests/resources/example-local-dataset-two-prior-datasets/metadata.json
@@ -1,1 +1,1 @@
-{"timestamp": "2025-01", "prior-datasets": ["../example-local-dataset-no-prior-datasets/", "../example-local-dataset-no-prior-datasets/"], "lag": "lag-2"}
+{"timestamp": "2025-01", "prior-datasets": ["../example-local-dataset-no-prior-datasets/", "../example-local-dataset-no-prior-datasets/"], "snapshot": 3}

--- a/tests/resources/example-local-dataset-two-prior-datasets/metadata.json
+++ b/tests/resources/example-local-dataset-two-prior-datasets/metadata.json
@@ -1,1 +1,1 @@
-{"timestamp": "2025-01", "prior-datasets": ["../example-local-dataset-no-prior-datasets/", "../example-local-dataset-no-prior-datasets/"], "snapshot": 3}
+{"timestamp": "2025-01", "prior-datasets": ["../example-local-dataset-no-prior-datasets/", "../example-local-dataset-no-prior-datasets/"], "snapshot": "s3"}

--- a/tests/resources/example-local-dataset-web-no-prior-datasets/metadata.json
+++ b/tests/resources/example-local-dataset-web-no-prior-datasets/metadata.json
@@ -2,5 +2,5 @@
     "base": "longeval-web",
     "timestamp": "2022-06",
     "prior-datasets": [],
-    "snapshot": 3
+    "snapshot": "s3"
 }

--- a/tests/resources/example-local-dataset-web-no-prior-datasets/metadata.json
+++ b/tests/resources/example-local-dataset-web-no-prior-datasets/metadata.json
@@ -2,5 +2,5 @@
     "base": "longeval-web",
     "timestamp": "2022-06",
     "prior-datasets": [],
-    "lag": "lag-3"
+    "snapshot": 3
 }

--- a/tests/resources/example-local-dataset-web-two-prior-datasets/metadata.json
+++ b/tests/resources/example-local-dataset-web-two-prior-datasets/metadata.json
@@ -2,5 +2,5 @@
     "base": "longeval-web",
     "timestamp": "2022-06",
     "prior-datasets": ["prior-dataset-01", "prior-dataset-02"],
-    "lag": "lag-4"
+    "snapshot": 4
 }

--- a/tests/resources/example-local-dataset-web-two-prior-datasets/metadata.json
+++ b/tests/resources/example-local-dataset-web-two-prior-datasets/metadata.json
@@ -2,5 +2,5 @@
     "base": "longeval-web",
     "timestamp": "2022-06",
     "prior-datasets": ["prior-dataset-01", "prior-dataset-02"],
-    "snapshot": 4
+    "snapshot": "s3"
 }

--- a/tests/test_environment_variable_is_used_in_tira_sandbox.py
+++ b/tests/test_environment_variable_is_used_in_tira_sandbox.py
@@ -1,24 +1,47 @@
-import unittest
-from ir_datasets_longeval import load
-from pathlib import Path
 import os
+import unittest
+from pathlib import Path
+
+from ir_datasets_longeval import load
+
 
 class TestEnvironmentVariableIsUsedInTiraSandbox(unittest.TestCase):
 
     def test_local_dataset_without_prior_datasets(self):
-        os.environ["TIRA_INPUT_DATASET"] = str((Path(__file__).parent / "resources" / "example-local-dataset-no-prior-datasets").absolute().resolve())
+        os.environ["TIRA_INPUT_DATASET"] = str(
+            (
+                Path(__file__).parent
+                / "resources"
+                / "example-local-dataset-no-prior-datasets"
+            )
+            .absolute()
+            .resolve()
+        )
 
         expected_doc_ids = sorted(["77444382", "140120179", "44934830", "34195138"])
         expected_queries = {"1234-1234-1234-1234-1234": "selection bias"}
-        expected_qrels = [{'doc_id': '140120179', 'query_id': '1234-1234-1234-1234-1234', 'rel': 2}]
+        expected_qrels = [
+            {"doc_id": "140120179", "query_id": "1234-1234-1234-1234-1234", "rel": 2}
+        ]
         dataset = load("THIS-DOES-NOT-EXIST")
 
         self.assertIsNotNone(dataset)
-        self.assertEqual(expected_doc_ids, sorted([i.doc_id for i in dataset.docs_iter()]))
-        self.assertEqual(expected_queries, {i.query_id: i.default_text() for i in dataset.queries_iter()})
-        self.assertEqual(expected_qrels, [{"query_id": i.query_id, "doc_id": i.doc_id, "rel": i.relevance} for i in dataset.qrels_iter()])
+        self.assertEqual(
+            expected_doc_ids, sorted([i.doc_id for i in dataset.docs_iter()])
+        )
+        self.assertEqual(
+            expected_queries,
+            {i.query_id: i.default_text() for i in dataset.queries_iter()},
+        )
+        self.assertEqual(
+            expected_qrels,
+            [
+                {"query_id": i.query_id, "doc_id": i.doc_id, "rel": i.relevance}
+                for i in dataset.qrels_iter()
+            ],
+        )
         self.assertEqual(2024, dataset.get_timestamp().year)
-        self.assertEqual([], dataset.get_past_datasets())
+        self.assertEqual([], dataset.get_prior_datasets())
         docs_store = dataset.docs_store()
 
         for doc in expected_doc_ids:

--- a/tests/test_local_dataset.py
+++ b/tests/test_local_dataset.py
@@ -44,8 +44,8 @@ class TestLocalDataset(unittest.TestCase):
         )
         self.assertEqual(2024, dataset.get_timestamp().year)
         self.assertEqual([], dataset.get_prior_datasets())
-        self.assertEqual(1, dataset.get_snapshot())
-        self.assertEqual(None, dataset.get_prior_snapshots())
+        self.assertEqual("s1", dataset.get_snapshot())
+        self.assertEqual(None, dataset.get_datasets())
         docs_store = dataset.docs_store()
 
         for doc in expected_doc_ids:
@@ -81,7 +81,7 @@ class TestLocalDataset(unittest.TestCase):
         for doc in expected_doc_ids:
             self.assertEqual(doc, docs_store.get(doc).doc_id)
 
-        self.assertEqual(3, dataset.get_snapshot())
+        self.assertEqual("s3", dataset.get_snapshot())
         past_datasets = dataset.get_prior_datasets()
         self.assertEqual(2, len(past_datasets))
         for past_dataset in past_datasets:
@@ -124,8 +124,8 @@ class TestLocalDataset(unittest.TestCase):
         )
         self.assertEqual(2022, dataset.get_timestamp().year)
         self.assertEqual([], dataset.get_prior_datasets())
-        self.assertEqual(3, dataset.get_snapshot())
-        self.assertEqual(None, dataset.get_prior_snapshots())
+        self.assertEqual("s3", dataset.get_snapshot())
+        self.assertEqual(None, dataset.get_datasets())
         docs_store = dataset.docs_store()
 
         for doc in expected_doc_ids:
@@ -161,8 +161,8 @@ class TestLocalDataset(unittest.TestCase):
         for doc in expected_doc_ids:
             self.assertEqual(doc, docs_store.get(doc).doc_id)
 
-        self.assertEqual(4, dataset.get_snapshot())
-        self.assertEqual(None, dataset.get_prior_snapshots())
+        self.assertEqual("s3", dataset.get_snapshot())
+        self.assertEqual(None, dataset.get_datasets())
         past_datasets = dataset.get_prior_datasets()
         self.assertEqual(2, len(past_datasets))
         for past_dataset in past_datasets:

--- a/tests/test_local_dataset.py
+++ b/tests/test_local_dataset.py
@@ -43,9 +43,9 @@ class TestLocalDataset(unittest.TestCase):
             ],
         )
         self.assertEqual(2024, dataset.get_timestamp().year)
-        self.assertEqual([], dataset.get_past_datasets())
-        self.assertEqual("lag-1", dataset.get_lag())
-        self.assertEqual(None, dataset.get_lags())
+        self.assertEqual([], dataset.get_prior_datasets())
+        self.assertEqual(1, dataset.get_snapshot())
+        self.assertEqual(None, dataset.get_prior_snapshots())
         docs_store = dataset.docs_store()
 
         for doc in expected_doc_ids:
@@ -81,13 +81,12 @@ class TestLocalDataset(unittest.TestCase):
         for doc in expected_doc_ids:
             self.assertEqual(doc, docs_store.get(doc).doc_id)
 
-        self.assertEqual("lag-2", dataset.get_lag())
-        self.assertEqual(None, dataset.get_lags())
-        past_datasets = dataset.get_past_datasets()
+        self.assertEqual(3, dataset.get_snapshot())
+        past_datasets = dataset.get_prior_datasets()
         self.assertEqual(2, len(past_datasets))
         for past_dataset in past_datasets:
             self.assertEqual(2024, past_dataset.get_timestamp().year)
-            self.assertEqual(0, len(past_dataset.get_past_datasets()))
+            self.assertEqual(0, len(past_dataset.get_prior_datasets()))
 
     def test_local_dataset_web_without_prior_datasets(self):
         expected_doc_ids = sorted(["16961", "25648", "19467"])
@@ -124,9 +123,9 @@ class TestLocalDataset(unittest.TestCase):
             ],
         )
         self.assertEqual(2022, dataset.get_timestamp().year)
-        self.assertEqual([], dataset.get_past_datasets())
-        self.assertEqual("lag-3", dataset.get_lag())
-        self.assertEqual(None, dataset.get_lags())
+        self.assertEqual([], dataset.get_prior_datasets())
+        self.assertEqual(3, dataset.get_snapshot())
+        self.assertEqual(None, dataset.get_prior_snapshots())
         docs_store = dataset.docs_store()
 
         for doc in expected_doc_ids:
@@ -162,11 +161,10 @@ class TestLocalDataset(unittest.TestCase):
         for doc in expected_doc_ids:
             self.assertEqual(doc, docs_store.get(doc).doc_id)
 
-
-        self.assertEqual("lag-4", dataset.get_lag())
-        self.assertEqual(None, dataset.get_lags())
-        past_datasets = dataset.get_past_datasets()
+        self.assertEqual(4, dataset.get_snapshot())
+        self.assertEqual(None, dataset.get_prior_snapshots())
+        past_datasets = dataset.get_prior_datasets()
         self.assertEqual(2, len(past_datasets))
         for past_dataset in past_datasets:
             self.assertEqual(2022, past_dataset.get_timestamp().year)
-            self.assertEqual(0, len(past_dataset.get_past_datasets()))
+            self.assertEqual(0, len(past_dataset.get_prior_datasets()))

--- a/tests/test_official_datasets.py
+++ b/tests/test_official_datasets.py
@@ -1,7 +1,4 @@
-import json
 import unittest
-
-import pytest
 
 from ir_datasets_longeval import load
 
@@ -40,7 +37,8 @@ class TestOfficialDatasets(unittest.TestCase):
         self.assertEqual([], dataset.get_prior_datasets())
 
         # Lag
-        self.assertEqual(1, dataset.get_snapshot())
+        self.assertEqual('2024-11-train', dataset.get_snapshot())
+        dataset.qrels_path()
 
     def test_web_dataset(self):
         dataset = load("longeval-web/2022-06")
@@ -74,7 +72,7 @@ class TestOfficialDatasets(unittest.TestCase):
         self.assertEqual([], dataset.get_prior_datasets())
 
         # Lag
-        self.assertEqual(1, dataset.get_snapshot())
+        self.assertEqual('2022-06', dataset.get_snapshot())
 
     def test_all_sci_datasets(self):
         dataset_id = "longeval-sci/*"
@@ -86,9 +84,9 @@ class TestOfficialDatasets(unittest.TestCase):
         with self.assertRaises(AttributeError):
             meta_dataset.docs_iter()
 
-        lags = meta_dataset.get_prior_snapshots()
+        lags = meta_dataset.get_datasets()
         self.assertEqual(1, len(lags))
-        self.assertEqual(1, lags[0].get_snapshot())
+        self.assertEqual('2024-11-train', lags[0].get_snapshot())
 
     def test_all_web_datasets(self):
         dataset_id = "longeval-web/*"
@@ -100,6 +98,6 @@ class TestOfficialDatasets(unittest.TestCase):
         with self.assertRaises(AttributeError):
             meta_dataset.docs_iter()
 
-        lags = meta_dataset.get_prior_snapshots()
+        lags = meta_dataset.get_datasets()
         self.assertEqual(9, len(lags))
-        self.assertEqual(1, lags[0].get_snapshot())
+        self.assertEqual("2022-06", lags[0].get_snapshot())

--- a/tests/test_official_datasets.py
+++ b/tests/test_official_datasets.py
@@ -7,13 +7,10 @@ from ir_datasets_longeval import load
 
 
 class TestOfficialDatasets(unittest.TestCase):
-    def test_sci_dataset(self):
+    def test_longeval_sci_2024_11_train(self):
         dataset = load("longeval-sci/2024-11/train")
 
         expected_queries = {"ce5bfacf-8652-4bc1-a5b0-6144a917fb1c": "streptomyces"}
-        expected_qrels = [
-            {"doc_id": "140120179", "query_id": "1234-1234-1234-1234-1234", "rel": 2}
-        ]
 
         # Dataset
         self.assertIsNotNone(dataset)
@@ -40,10 +37,10 @@ class TestOfficialDatasets(unittest.TestCase):
         self.assertEqual(2024, dataset.get_timestamp().year)
 
         # Prior datasets
-        self.assertEqual([], dataset.get_past_datasets())
+        self.assertEqual([], dataset.get_prior_datasets())
 
         # Lag
-        self.assertEqual("lag-0", dataset.get_lag())
+        self.assertEqual(1, dataset.get_snapshot())
 
     def test_web_dataset(self):
         dataset = load("longeval-web/2022-06")
@@ -74,10 +71,10 @@ class TestOfficialDatasets(unittest.TestCase):
         self.assertEqual(2022, dataset.get_timestamp().year)
 
         # Prior datasets
-        self.assertEqual([], dataset.get_past_datasets())
+        self.assertEqual([], dataset.get_prior_datasets())
 
         # Lag
-        self.assertEqual("lag-0", dataset.get_lag())
+        self.assertEqual(1, dataset.get_snapshot())
 
     def test_all_sci_datasets(self):
         dataset_id = "longeval-sci/*"
@@ -89,9 +86,9 @@ class TestOfficialDatasets(unittest.TestCase):
         with self.assertRaises(AttributeError):
             meta_dataset.docs_iter()
 
-        lags = meta_dataset.get_lags()
+        lags = meta_dataset.get_prior_snapshots()
         self.assertEqual(1, len(lags))
-        self.assertEqual("lag-0", lags[0].get_lag())
+        self.assertEqual(1, lags[0].get_snapshot())
 
     def test_all_web_datasets(self):
         dataset_id = "longeval-web/*"
@@ -103,59 +100,6 @@ class TestOfficialDatasets(unittest.TestCase):
         with self.assertRaises(AttributeError):
             meta_dataset.docs_iter()
 
-        lags = meta_dataset.get_lags()
+        lags = meta_dataset.get_prior_snapshots()
         self.assertEqual(9, len(lags))
-        self.assertEqual("lag-0", lags[0].get_lag())
-
-
-with open("ir_datasets_longeval/metadata.json") as f:
-    SPECS = json.load(f)
-
-
-class TestOfficialDatasets2(unittest.TestCase):
-    def test_all_official_datasets(self):
-        previous_lags = []
-        for dataset_name, spec in SPECS.items():
-            with self.subTest(dataset=dataset_name):
-                dataset = load(dataset_name)
-
-                # Dataset
-                self.assertIsNotNone(dataset)
-                example_doc = dataset.docs_iter().__next__()
-
-                # Queries
-                if queries := spec.get("queries"):
-                    actual_queries = {
-                        i.query_id: i.default_text() for i in dataset.queries_iter()
-                    }
-                    self.assertEqual(queries["count"], len(actual_queries))
-
-                # Qrels
-                if qrels := spec.get("qrels"):
-                    self.assertEqual(qrels["count"], len(list(dataset.qrels_iter())))
-
-                # Docs
-                if docs := spec.get("docs"):
-                    num_docs = dataset.docs_count()
-                    self.assertEqual(docs["count"], num_docs)
-
-                    # Docstore
-                    docstore = dataset.docs_store()
-                    example_doc = dataset.docs_iter().__next__().doc_id
-                    self.assertEqual(example_doc, docstore.get(example_doc).doc_id)
-
-                # # Timestamp
-                # self.assertEqual(2024, dataset.get_timestamp().year)
-
-                # Lag
-                if lag := spec.get("lag"):
-                    # # previous lags
-                    # self.assertEqual(len(previous_lags), dataset.get_lags())
-
-                    self.assertEqual(lag, dataset.get_lag())
-                    previous_lags.append(lag)
-
-                    # Prior datasets
-                    self.assertEqual(
-                        len(previous_lags), len(dataset.get_past_datasets())
-                    )
+        self.assertEqual(1, lags[0].get_snapshot())

--- a/tests/test_spot_check_datasets.py
+++ b/tests/test_spot_check_datasets.py
@@ -1,5 +1,4 @@
 import unittest
-from pathlib import Path
 
 from ir_datasets_longeval import load
 
@@ -73,7 +72,11 @@ class TestSpotCheckDatasets(unittest.TestCase):
         with self.assertRaises(AttributeError):
             meta_dataset.docs_iter()
 
-        lags = meta_dataset.get_prior_snapshots()
-        self.assertEqual(2, len(lags))
-        self.assertEqual(1, lags[0].get_snapshot())
-        self.assertEqual(2, lags[1].get_snapshot())
+        datasets = meta_dataset.get_datasets()
+        self.assertEqual(2, len(datasets))
+        self.assertEqual("s1", datasets[0].get_snapshot())
+        self.assertEqual("s3", datasets[1].get_snapshot())
+
+        for dataset in datasets:
+            dataset.get_prior_datasets()
+            dataset.qrels_path()

--- a/tests/test_spot_check_datasets.py
+++ b/tests/test_spot_check_datasets.py
@@ -74,8 +74,8 @@ class TestSpotCheckDatasets(unittest.TestCase):
 
         datasets = meta_dataset.get_datasets()
         self.assertEqual(2, len(datasets))
-        self.assertEqual("s1", datasets[0].get_snapshot())
-        self.assertEqual("s3", datasets[1].get_snapshot())
+        self.assertEqual("2024-10", datasets[0].get_snapshot())
+        self.assertEqual("2024-11", datasets[1].get_snapshot())
 
         for dataset in datasets:
             dataset.get_prior_datasets()

--- a/tests/test_spot_check_datasets.py
+++ b/tests/test_spot_check_datasets.py
@@ -1,48 +1,67 @@
 import unittest
-from ir_datasets_longeval import load
 from pathlib import Path
+
+from ir_datasets_longeval import load
+
 
 class TestSpotCheckDatasets(unittest.TestCase):
     def test_local_dataset_without_prior_datasets(self):
-        expected_queries = {'1901ce75-b35a-4dde-b331-e5e5366dd188': 'ransomware detection', '2f85a909-c4bf-49b6-b7a6-819f7d45f44c': 'chatgpt', 'e6195d15-a4b6-4ce7-9b4f-cf39acdd37e3': 'eye movement'}
+        expected_queries = {
+            "1901ce75-b35a-4dde-b331-e5e5366dd188": "ransomware detection",
+            "2f85a909-c4bf-49b6-b7a6-819f7d45f44c": "chatgpt",
+            "e6195d15-a4b6-4ce7-9b4f-cf39acdd37e3": "eye movement",
+        }
         dataset_id = "longeval-sci/spot-check/no-prior-data"
         dataset = load(dataset_id)
 
         self.assertIsNotNone(dataset)
         self.assertEqual(135, len([i.doc_id for i in dataset.docs_iter()]))
-        self.assertEqual(expected_queries, {i.query_id: i.default_text() for i in dataset.queries_iter()})
+        self.assertEqual(
+            expected_queries,
+            {i.query_id: i.default_text() for i in dataset.queries_iter()},
+        )
         self.assertEqual(63, len(list(dataset.qrels_iter())))
         self.assertEqual(2024, dataset.get_timestamp().year)
-        self.assertEqual([], dataset.get_past_datasets())
+        self.assertEqual([], dataset.get_prior_datasets())
         docs_store = dataset.docs_store()
 
-        for doc in ['159473507', '137793115']:
+        for doc in ["159473507", "137793115"]:
             self.assertEqual(doc, docs_store.get(doc).doc_id)
 
     def test_local_dataset_with_prior_datasets(self):
-        expected_queries = {'1901ce75-b35a-4dde-b331-e5e5366dd188': 'ransomware detection', '2f85a909-c4bf-49b6-b7a6-819f7d45f44c': 'chatgpt', 'e6195d15-a4b6-4ce7-9b4f-cf39acdd37e3': 'eye movement'}
+        expected_queries = {
+            "1901ce75-b35a-4dde-b331-e5e5366dd188": "ransomware detection",
+            "2f85a909-c4bf-49b6-b7a6-819f7d45f44c": "chatgpt",
+            "e6195d15-a4b6-4ce7-9b4f-cf39acdd37e3": "eye movement",
+        }
         dataset_id = "longeval-sci/spot-check/with-prior-data"
         dataset = load(dataset_id)
 
         self.assertIsNotNone(dataset)
         self.assertEqual(135, len([i.doc_id for i in dataset.docs_iter()]))
-        self.assertEqual(expected_queries, {i.query_id: i.default_text() for i in dataset.queries_iter()})
+        self.assertEqual(
+            expected_queries,
+            {i.query_id: i.default_text() for i in dataset.queries_iter()},
+        )
         self.assertEqual(63, len(list(dataset.qrels_iter())))
 
         self.assertEqual(2024, dataset.get_timestamp().year)
         docs_store = dataset.docs_store()
 
-        for doc in ['159473507', '137793115']:
+        for doc in ["159473507", "137793115"]:
             self.assertEqual(doc, docs_store.get(doc).doc_id)
 
-        self.assertEqual(2, len(dataset.get_past_datasets()))
-        for past_dataset in dataset.get_past_datasets():
+        self.assertEqual(2, len(dataset.get_prior_datasets()))
+        for past_dataset in dataset.get_prior_datasets():
             self.assertEqual(135, len([i.doc_id for i in past_dataset.docs_iter()]))
-            self.assertEqual(expected_queries, {i.query_id: i.default_text() for i in past_dataset.queries_iter()})
+            self.assertEqual(
+                expected_queries,
+                {i.query_id: i.default_text() for i in past_dataset.queries_iter()},
+            )
             docs_store = past_dataset.docs_store()
             self.assertTrue(len(list(past_dataset.qrels_iter())) >= 10)
 
-            for doc in ['159473507', '137793115']:
+            for doc in ["159473507", "137793115"]:
                 self.assertEqual(doc, docs_store.get(doc).doc_id)
 
     def test_all_spot_check_datasets(self):
@@ -54,8 +73,7 @@ class TestSpotCheckDatasets(unittest.TestCase):
         with self.assertRaises(AttributeError):
             meta_dataset.docs_iter()
 
-        lags = meta_dataset.get_lags()
+        lags = meta_dataset.get_prior_snapshots()
         self.assertEqual(2, len(lags))
-        self.assertEqual("lag-3", lags[0].get_lag())
-        self.assertEqual("lag-4", lags[1].get_lag())
-
+        self.assertEqual(1, lags[0].get_snapshot())
+        self.assertEqual(2, lags[1].get_snapshot())


### PR DESCRIPTION
This is mainly a cosmetic fix that renames some parts in the API:
- Lag is renamed to snapshot, as we discussed earlier, this should be a little more intuitive
- The naming of functions that provide prior information is unified