### PR TITLE
fix longeval-sci/2024-11 loads wrong qrels

### DIFF
--- a/ir_datasets_longeval/longeval_sci.py
+++ b/ir_datasets_longeval/longeval_sci.py
@@ -83,6 +83,7 @@ def docs_iter_without_duplicates(iterator):
             returned.add(doc.doc_id)
             yield doc
 
+
 class LongEvalSciDataset(Dataset):
     def __init__(
         self,
@@ -165,6 +166,10 @@ class LongEvalSciDataset(Dataset):
         qrels_path = base_path / "qrels.txt"
         if qrels_path.exists() and qrels_path.is_file():
             qrels = TrecQrels(ExtractedPath(qrels_path), QREL_DEFS)
+
+        # BUG: for longeval-sci/2024-11, the basepath from 2024-11/train is provided which contains qrels for 2024-11/train. To temporarily prevent that the wrong queries are loaded we overwrite the qrels here again. This will be fixed with the test qrels release.
+        if snapshot == "2024-11" and queries_path.name == "queries_2024-11_test.txt":
+            qrels = None
 
         super().__init__(docs, queries, qrels, documentation)
         original_iter = self.docs_iter
@@ -295,7 +300,9 @@ def register():
     if f"{NAME}/*" in registry:
         return
     registry.register(f"{NAME}/*", MetaDataset(list(subsets.values())))
-    
+
     if f"{NAME}/clef-2025-test" in registry:
         return
-    registry.register(f"{NAME}/clef-2025-test", MetaDataset([subsets["2024-11"], subsets["2025-01"]]))
+    registry.register(
+        f"{NAME}/clef-2025-test", MetaDataset([subsets["2024-11"], subsets["2025-01"]])
+    )

--- a/tests/test_official_datasets.py
+++ b/tests/test_official_datasets.py
@@ -24,7 +24,7 @@ class TestOfficialDatasets(unittest.TestCase):
 
         # Docs
         self.assertIsNotNone(example_doc.doc_id)
-        self.assertEqual("68859258", example_doc.doc_id)
+        self.assertEqual("127164364", example_doc.doc_id)
 
         # Docstore
         docs_store = dataset.docs_store()
@@ -39,6 +39,11 @@ class TestOfficialDatasets(unittest.TestCase):
         # Lag
         self.assertEqual("2024-11-train", dataset.get_snapshot())
         dataset.qrels_path()
+
+        # components
+        self.assertEqual(dataset.has_qrels(), True)
+        self.assertEqual(dataset.has_queries(), True)
+        self.assertEqual(dataset.has_docs(), True)
 
     def test_longeval_sci_2024_11(self):
         dataset = load("longeval-sci/2024-11")
@@ -57,7 +62,7 @@ class TestOfficialDatasets(unittest.TestCase):
 
         # Docs
         self.assertIsNotNone(example_doc.doc_id)
-        self.assertEqual("68859258", example_doc.doc_id)
+        self.assertEqual("127164364", example_doc.doc_id)
 
         # Docstore
         docs_store = dataset.docs_store()
@@ -71,6 +76,11 @@ class TestOfficialDatasets(unittest.TestCase):
 
         # Lag
         self.assertEqual("2024-11", dataset.get_snapshot())
+
+        # components
+        self.assertEqual(dataset.has_qrels(), False)
+        self.assertEqual(dataset.has_queries(), True)
+        self.assertEqual(dataset.has_docs(), True)
 
     def test_longeval_sci_2025_02(self):
         dataset = load("longeval-sci/2025-01")
@@ -89,7 +99,7 @@ class TestOfficialDatasets(unittest.TestCase):
 
         # Docs
         self.assertIsNotNone(example_doc.doc_id)
-        self.assertEqual("155554680", example_doc.doc_id)
+        self.assertEqual("57282207", example_doc.doc_id)
 
         # Docstore
         docs_store = dataset.docs_store()
@@ -103,6 +113,11 @@ class TestOfficialDatasets(unittest.TestCase):
 
         # Lag
         self.assertEqual("2025-01", dataset.get_snapshot())
+
+        # components
+        self.assertEqual(dataset.has_qrels(), False)
+        self.assertEqual(dataset.has_queries(), True)
+        self.assertEqual(dataset.has_docs(), True)
 
     def test_web_dataset(self):
         dataset = load("longeval-web/2022-06")


### PR DESCRIPTION
This PR (temporarily) fixes the bug that for the `longeval-sci/2024-11` dataset qrels of `longeval-sci/2024-11/train` are loaded.

Since the  `longeval-sci/2024-11` dataset is one of the two test datasets in the CLEF Lab, currently no qrels are available. This test snapshot uses the same document collection as `longeval-sci/2024-11/train` and therefore the base_path of `longeval-sci/2024-11/train` is provided. To prevent now that the `longeval-sci/2024-11/train` qrels are loaded a temporarily fix that checks the snapshot name and the query path overwrites the qrels.
As soon as the test qrels will be released, this fix will become obsolete. 